### PR TITLE
Fix issue where separators are not being displayed in lualine

### DIFF
--- a/.config/nvim/after/plugin/lualine.rc.lua
+++ b/.config/nvim/after/plugin/lualine.rc.lua
@@ -5,8 +5,8 @@ lualine.setup {
   options = {
     icons_enabled = true,
     theme = 'solarized_dark',
-    section_separators = {'', ''},
-    component_separators = {'', ''},
+    section_separators = {left = '', right = ''},
+    component_separators = {left = '', right = ''},
     disabled_filetypes = {}
   },
   sections = {


### PR DESCRIPTION
I believe this is a mistype, separators will not display if vars are not initialized. At least in Neovim 0.5.1.