### PR TITLE
ADD <Tab> navigation for cmp

### DIFF
--- a/.config/nvim/after/plugin/cmp.rc.vim
+++ b/.config/nvim/after/plugin/cmp.rc.vim
@@ -2,11 +2,8 @@ if !exists('g:loaded_cmp') | finish | endif
 
 set completeopt=menuone,noinsert,noselect
 
-" Use <Tab> and <S-Tab> to navigate through popup menu
-inoremap <expr> <Tab>   pumvisible() ? "\<C-n>" : "\<Tab>"
-inoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"
-
 lua <<EOF
+  local luasnip = require 'luasnip'
   local cmp = require'cmp'
   local lspkind = require'lspkind'
 
@@ -17,6 +14,24 @@ lua <<EOF
       end,
     },
     mapping = {
+      ['<Tab>'] = function(fallback)
+        if cmp.visible() then
+          cmp.select_next_item()
+        elseif luasnip.expand_or_jumpable() then
+          luasnip.expand_or_jump()
+        else
+          fallback()
+        end
+      end,
+      ['<S-Tab>'] = function(fallback)
+        if cmp.visible() then
+          cmp.select_prev_item()
+        elseif luasnip.jumpable(-1) then
+          luasnip.jump(-1)
+        else
+          fallback()
+        end
+      end,
       ['<C-d>'] = cmp.mapping.scroll_docs(-4),
       ['<C-f>'] = cmp.mapping.scroll_docs(4),
       ['<C-Space>'] = cmp.mapping.complete(),
@@ -28,6 +43,8 @@ lua <<EOF
     },
     sources = cmp.config.sources({
       { name = 'nvim_lsp' },
+    }, {
+      { name = 'luasnip' },
     }, {
       { name = 'buffer' },
     }),


### PR DESCRIPTION
I noticed that after your changes with `cmp` we lost the <Tab> navigation through the popup menu. `inoremap` Doesn't work in this case. I Walked through the [cmp](https://github.com/hrsh7th/nvim-cmp) docs and issues and this implementation solves the problem. Please consider to merge this or feel free to fix this on your own way.

I also thought to fix it with adding this pice of code:
```
    ["<Tab>"] = Cmp.mapping.select_next_item({behavior=Cmp.SelectBehavior.Insert}),
    ["<S-Tab>"] = Cmp.mapping.select_prev_item({behavior=Cmp.SelectBehavior.Insert}),
```
but here we don't have fallback option(do we need it? I don't know). This is more readable solution of course.

Kind regards,