### PR TITLE
UPDATE: Add config-linux.fish

### DIFF
--- a/.config/fish/config-linux.fish
+++ b/.config/fish/config-linux.fish
@@ -1,0 +1,4 @@
+if type -q exa
+  alias ll "exa -l -g --icons"
+  alias lla "ll -a"
+end

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -44,7 +44,7 @@ switch (uname)
   case Darwin
     source (dirname (status --current-filename))/config-osx.fish
   case Linux
-    # Do nothing
+    source (dirname (status --current-filename))/config-linux.fish
   case '*'
     source (dirname (status --current-filename))/config-windows.fish
 end


### PR DESCRIPTION
Thanks a lot @craftzdog  for your dotfiles. I used them for linux operating system. Saved ton of time.
EXA can be installed with **apt** or **apt-get** only if users have Ubuntu Release 20.10(Groovy Gorilla) . In other cases, user can install EXA through Homebrew.
