### PR TITLE
fix issue with lualine diagnostics source

### DIFF
--- a/.config/nvim/after/plugin/lualine.rc.lua
+++ b/.config/nvim/after/plugin/lualine.rc.lua
@@ -18,7 +18,7 @@ lualine.setup {
       path = 0 -- 0 = just filename, 1 = relative path, 2 = absolute path
     }},
     lualine_x = {
-      { 'diagnostics', sources = {"nvim_lsp"}, symbols = {error = ' ', warn = ' ', info = ' ', hint = ' '} },
+      { 'diagnostics', sources = {"nvim_diagnostic"}, symbols = {error = ' ', warn = ' ', info = ' ', hint = ' '} },
       'encoding',
       'filetype'
     },


### PR DESCRIPTION
after installing the nvim public dotfiles, and using :PlugInstall to install all plugins, everything works well, except for a small error
that gives you the next log:

"Diagnostics source `nvim_lsp` has been deprecated in favour of `nvim_diagnostic
nvim_diagnostic shows diagnostics from neovim's diagnostics api
while nvim_lsp used to only show lsp diagnostics.

You've something like this your config.
lua
  {'diagnostics', sources = {'nvim_lsp'}}
It needs to be updated to:
lua
  {'diagnostics', sources = {'nvim_diagnostic'}}"

following the log recommendation i changed the source in the "lualine.rc.lua" file
and the error disappeared, and everything works fine.

i dont know if its the best solution or if you want to change the source to another one, but i hope this was at least helpful :(

hope you have a great day!,
greetings from chile.