### PR TITLE
feat: fix deprecation warning

### DIFF
--- a/.config/nvim/after/plugin/lspconfig.rc.vim
+++ b/.config/nvim/after/plugin/lspconfig.rc.vim
@@ -43,10 +43,10 @@ local on_attach = function(client, bufnr)
 
   -- formatting
   if client.name == 'tsserver' then
-    client.resolved_capabilities.document_formatting = false
+    client.server_capabilities.document_formatting = false
   end
 
-  if client.resolved_capabilities.document_formatting then
+  if client.server_capabilities.document_formatting then
     vim.api.nvim_command [[augroup Format]]
     vim.api.nvim_command [[autocmd! * <buffer>]]
     vim.api.nvim_command [[autocmd BufWritePre <buffer> lua vim.lsp.buf.formatting_seq_sync()]]


### PR DESCRIPTION
### Changes Proposed:
- fix lsp deprecation warning.

Deprecation warning message: [LSP] Accessing client.resolved_capabilities is deprecated, update your plugins or configuration to access client.server_capabilities instead. The new key/value pairs in server_capabilities directly match those defined in the language server protocol.