### PR TITLE
fix(powershell): `Import-Module oh-my-posh` is deprecated

### DIFF
--- a/.config/powershell/user_profile.ps1
+++ b/.config/powershell/user_profile.ps1
@@ -2,7 +2,7 @@
 [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
 
 Import-Module posh-git
-Import-Module oh-my-posh
+#Import-Module oh-my-posh
 $omp_config = Join-Path $PSScriptRoot ".\takuya.omp.json"
 oh-my-posh --init --shell pwsh --config $omp_config | Invoke-Expression
 
@@ -13,6 +13,7 @@ Set-PSReadLineOption -EditMode Emacs
 Set-PSReadLineOption -BellStyle None
 Set-PSReadLineKeyHandler -Chord 'Ctrl+d' -Function DeleteChar
 Set-PSReadLineOption -PredictionSource History
+Set-PSReadLineOption -PredictionViewStyle ListView
 
 # Fzf
 Import-Module PSFzf


### PR DESCRIPTION
Removed deprecated module oh-my-posh (install using winget) and added PSReadLine ViewStyle option which was missing.

- For oh-my-posh:
`winget install oh-my-posh`