### PR TITLE
fix(nvim): add missing protected call

### DIFF
--- a/.config/nvim/after/plugin/gitsigns.rc.lua
+++ b/.config/nvim/after/plugin/gitsigns.rc.lua
@@ -1,1 +1,4 @@
-require('gitsigns').setup {}
+local status, gitsigns = pcall(require, "gitsigns")
+if (not status) then return end
+
+gitsigns.setup {}

--- a/.config/nvim/lua/craftzdog/plugins.lua
+++ b/.config/nvim/lua/craftzdog/plugins.lua
@@ -28,7 +28,7 @@ packer.startup(function(use)
   use 'L3MON4D3/LuaSnip'
   use {
     'nvim-treesitter/nvim-treesitter',
-    run = ':TSUpdate'
+    run = function() require('nvim-treesitter.install').update({ with_sync = true }) end,
   }
   use 'kyazdani42/nvim-web-devicons' -- File icons
   use 'nvim-telescope/telescope.nvim'


### PR DESCRIPTION
- Added the missing protected call for the gitsigns plugin, now it no longer gives an error on fresh installs.
- Fixed `:TSUpdate` error upon first treesitter installation [See here](https://github.com/nvim-treesitter/nvim-treesitter/wiki/Installation#packernvim)