### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .*~
 *~
 .DS_Store
+._*
 *.sw[po]
 tags
 TAGS


### PR DESCRIPTION
To avoid pulling ._ files to repository. These file created to store file information that would otherwise go into an extended attribute on HFS+ (Apple native) or Unix/UFS volumes; in earlier Mac OS this would be the resource fork.