### PR TITLE
hotfix/lspconfig

### DIFF
--- a/.config/nvim/plugin/null-ls.rc.lua
+++ b/.config/nvim/plugin/null-ls.rc.lua
@@ -16,8 +16,7 @@ null_ls.setup {
       vim.api.nvim_create_autocmd("BufWritePre", {
         group = augroup_format,
         buffer = 0,
-        callback = function() vim.lsp.buf.formatting_seq_sync() end
-      })
+        callback = function() vim.lsp.buf.format({ async = true }) end })
     end
   end,
 }


### PR DESCRIPTION
- chore(nvim): migrate bufferline config migrate akinsho/bufferline.nvim config to v2.6.0 see akinsho/bufferline.nvim#499 for more details
- fix(nvim): format-on-save not working in some cases
- fix(nvim): use my username as a module name to avoid namespace collisions
- fix(nvim): add missing protected call
- chore(nvim): refactor
- fix(tmux): wrong paths
- chore(neovim): update null-ls.rc.lua
