### PR TITLE
fix(lspsaga): remove signature_help is deprecated.

### DIFF
--- a/.config/nvim/plugin/lspsaga.rc.lua
+++ b/.config/nvim/plugin/lspsaga.rc.lua
@@ -11,6 +11,5 @@ local opts = { noremap = true, silent = true }
 vim.keymap.set('n', '<C-j>', '<Cmd>Lspsaga diagnostic_jump_next<CR>', opts)
 vim.keymap.set('n', 'K', '<Cmd>Lspsaga hover_doc<CR>', opts)
 vim.keymap.set('n', 'gd', '<Cmd>Lspsaga lsp_finder<CR>', opts)
-vim.keymap.set('i', '<C-k>', '<Cmd>Lspsaga signature_help<CR>', opts)
 vim.keymap.set('n', 'gp', '<Cmd>Lspsaga peek_definition<CR>', opts)
 vim.keymap.set('n', 'gr', '<Cmd>Lspsaga rename<CR>', opts)


### PR DESCRIPTION
glepnir already remove signature_help command.
- https://github.com/glepnir/lspsaga.nvim/issues/513.