### PR TITLE
fix(lspsaga): changing signature_help to vim.lsp.buf.signaturehelp

### DIFF
--- a/.config/nvim/plugin/lspsaga.rc.lua
+++ b/.config/nvim/plugin/lspsaga.rc.lua
@@ -11,6 +11,7 @@ local opts = { noremap = true, silent = true }
 vim.keymap.set('n', '<C-j>', '<Cmd>Lspsaga diagnostic_jump_next<CR>', opts)
 vim.keymap.set('n', 'K', '<Cmd>Lspsaga hover_doc<CR>', opts)
 vim.keymap.set('n', 'gd', '<Cmd>Lspsaga lsp_finder<CR>', opts)
-vim.keymap.set('i', '<C-k>', '<Cmd>Lspsaga signature_help<CR>', opts)
+-- vim.keymap.set('i', '<C-k>', '<Cmd>Lspsaga signature_help<CR>', opts)
+vim.keymap.set('i', '<C-k>', '<cmd>lua vim.lsp.buf.signature_help()<CR>', opts)
 vim.keymap.set('n', 'gp', '<Cmd>Lspsaga peek_definition<CR>', opts)
 vim.keymap.set('n', 'gr', '<Cmd>Lspsaga rename<CR>', opts)


### PR DESCRIPTION
+ nvim/plugin/lspsaga.rc.lua
- These command `signaturehelp` have been deprecated or being hold due 'not stable now'. Since they remove it, we are changing to `vim.lsp.buf.signaturehelp` until glepnir bringback `signature_help`, it should fix nil value that trigger for `i<C-k>` for now.
- https://github.com/glepnir/lspsaga.nvim/pull/456
- https://github.com/glepnir/lspsaga.nvim/issues/513