### PR TITLE
feat(nvim): enhance nvim-cmp for tailwindcss

### DIFF
--- a/.config/nvim/after/plugin/cmp.rc.lua
+++ b/.config/nvim/after/plugin/cmp.rc.lua
@@ -2,6 +2,24 @@ local status, cmp = pcall(require, "cmp")
 if (not status) then return end
 local lspkind = require 'lspkind'
 
+function formatForTailwindCSS(entry, vim_item)
+  if vim_item.kind == 'Color' and entry.completion_item.documentation then
+    local _, _, r, g, b = string.find(entry.completion_item.documentation, '^rgb%((%d+), (%d+), (%d+)')
+    if r then
+      local color = string.format('%02x', r) .. string.format('%02x', g) .. string.format('%02x', b)
+      local group = 'Tw_' .. color
+      if vim.fn.hlID(group) < 1 then
+        vim.api.nvim_set_hl(0, group, { fg = '#' .. color })
+      end
+      vim_item.kind = "●"
+      vim_item.kind_hl_group = group
+      return vim_item
+    end
+  end
+  vim_item.kind = lspkind.symbolic(vim_item.kind) and lspkind.symbolic(vim_item.kind) or vim_item.kind
+  return vim_item
+end
+
 cmp.setup({
   snippet = {
     expand = function(args)
@@ -26,20 +44,7 @@ cmp.setup({
     format = lspkind.cmp_format({
       maxwidth = 50,
       before = function(entry, vim_item) -- for tailwind css autocomplete
-        if vim_item.kind == 'Color' and entry.completion_item.documentation then
-          local _, _, r, g, b = string.find(entry.completion_item.documentation, '^rgb%((%d+), (%d+), (%d+)')
-          if r then
-            local color = string.format('%02x', r) .. string.format('%02x', g) ..string.format('%02x', b)
-            local group = 'Tw_' .. color
-            if vim.fn.hlID(group) < 1 then
-              vim.api.nvim_set_hl(0, group, {fg = '#' .. color})
-            end
-            vim_item.kind = "⬤"
-            vim_item.kind_hl_group = group
-            return vim_item
-          end
-        end
-        vim_item.kind = lspkind.symbolic(vim_item.kind) and lspkind.symbolic(vim_item.kind) or vim_item.kind
+        vim_item = formatForTailwindCSS(entry, vim_item)
         return vim_item
       end
     })
@@ -50,7 +55,3 @@ vim.cmd [[
   set completeopt=menuone,noinsert,noselect
   highlight! default link CmpItemKind CmpItemMenuDefault
 ]]
-
--- " Use <Tab> and <S-Tab> to navigate through popup menu
--- inoremap <expr> <Tab>   pumvisible() ? "\<C-n>" : "\<Tab>"
--- inoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"

--- a/.config/nvim/after/plugin/cmp.rc.lua
+++ b/.config/nvim/after/plugin/cmp.rc.lua
@@ -23,7 +23,26 @@ cmp.setup({
     { name = 'buffer' },
   }),
   formatting = {
-    format = lspkind.cmp_format({ with_text = false, maxwidth = 50 })
+    format = lspkind.cmp_format({
+      maxwidth = 50,
+      before = function(entry, vim_item) -- for tailwind css autocomplete
+        if vim_item.kind == 'Color' and entry.completion_item.documentation then
+          local _, _, r, g, b = string.find(entry.completion_item.documentation, '^rgb%((%d+), (%d+), (%d+)')
+          if r then
+            local color = string.format('%02x', r) .. string.format('%02x', g) ..string.format('%02x', b)
+            local group = 'Tw_' .. color
+            if vim.fn.hlID(group) < 1 then
+              vim.api.nvim_set_hl(0, group, {fg = '#' .. color})
+            end
+            vim_item.kind = "⬤"
+            vim_item.kind_hl_group = group
+            return vim_item
+          end
+        end
+        vim_item.kind = lspkind.symbolic(vim_item.kind) and lspkind.symbolic(vim_item.kind) or vim_item.kind
+        return vim_item
+      end
+    })
   }
 })
 


### PR DESCRIPTION
# Description
Enhance Tailwind CSS's auto-completion, making it more like the official Tailwind CSS IntelliSense.

Now the icon of kinds on nvim-cmp dropdown will display the color of the class.

Before:
![image](https://user-images.githubusercontent.com/39915562/211147683-14a1fcf1-ecef-46f8-8c29-bd8d5f59ca60.png)
**After:**
![image](https://user-images.githubusercontent.com/39915562/211147879-cb8b8402-47ac-458f-ba34-6797683f8083.png)