### PR TITLE
fix(nvim): Switch from sumneko_lua to lua_ls

### DIFF
--- a/.config/nvim/plugin/lspconfig.lua
+++ b/.config/nvim/plugin/lspconfig.lua
@@ -84,7 +84,7 @@ nvim_lsp.sourcekit.setup {
   capabilities = capabilities,
 }
 
-nvim_lsp.sumneko_lua.setup {
+nvim_lsp.lua_ls.setup {
   capabilities = capabilities,
   on_attach = function(client, bufnr)
     on_attach(client, bufnr)


### PR DESCRIPTION
- Sumneko_lua is deprecated, instead it now uses lua_ls.
- Replaced sumneko_lua with lua_ls.