### PR TITLE
feat(nvim): adding nvim tree

### DIFF
--- a/.config/nvim/after/plugin/nvimtree.rc.lua
+++ b/.config/nvim/after/plugin/nvimtree.rc.lua
@@ -1,0 +1,32 @@
+local status, tree = pcall(require, "nvim-tree")
+if (not status) then
+  return
+end
+
+tree.setup({
+  sort_by = "case_sensitive",
+  view = {
+    adaptive_size = true,
+    mappings = {
+      list = {
+        { key = "u", action = "dir_up" },
+        { key = "N", action = "create" },
+      },
+    },
+  },
+  renderer = {
+    group_empty = true,
+  },
+  filters = {
+    dotfiles = false,
+  },
+})
+
+-- Disabling net and netrw for nvim-tree
+vim.g.loaded_netrw = 1
+vim.g.loaded_netrw_plugin = 1
+
+-- Setting Keymaps For nvimtree plugin
+vim.keymap.set('n', 'tt', ':NvimTreeToggle<CR>')
+vim.keymap.set('n', 'to', ':NvimTreeOpen ')
+vim.keymap.set('n', 'tq', ':NvimTreeClose<CR>')

--- a/.config/nvim/lua/craftzdog/plugins.lua
+++ b/.config/nvim/lua/craftzdog/plugins.lua
@@ -12,13 +12,13 @@ packer.startup(function(use)
     'svrana/neosolarized.nvim',
     requires = { 'tjdevries/colorbuddy.nvim' }
   }
-  use 'nvim-lualine/lualine.nvim' -- Statusline
-  use 'nvim-lua/plenary.nvim' -- Common utilities
-  use 'onsails/lspkind-nvim' -- vscode-like pictograms
-  use 'hrsh7th/cmp-buffer' -- nvim-cmp source for buffer words
-  use 'hrsh7th/cmp-nvim-lsp' -- nvim-cmp source for neovim's built-in LSP
-  use 'hrsh7th/nvim-cmp' -- Completion
-  use 'neovim/nvim-lspconfig' -- LSP
+  use 'nvim-lualine/lualine.nvim'       -- Statusline
+  use 'nvim-lua/plenary.nvim'           -- Common utilities
+  use 'onsails/lspkind-nvim'            -- vscode-like pictograms
+  use 'hrsh7th/cmp-buffer'              -- nvim-cmp source for buffer words
+  use 'hrsh7th/cmp-nvim-lsp'            -- nvim-cmp source for neovim's built-in LSP
+  use 'hrsh7th/nvim-cmp'                -- Completion
+  use 'neovim/nvim-lspconfig'           -- LSP
   use 'jose-elias-alvarez/null-ls.nvim' -- Use Neovim as a language server to inject LSP diagnostics, code actions, and more via Lua
   use 'williamboman/mason.nvim'
   use 'williamboman/mason-lspconfig.nvim'
@@ -50,4 +50,12 @@ packer.startup(function(use)
 
   use 'lewis6991/gitsigns.nvim'
   use 'dinhhuy258/git.nvim' -- For git blame & browse
+
+  use {
+    'nvim-tree/nvim-tree.lua',
+    requires = {
+      'nvim-tree/nvim-web-devicons'
+    },
+    tag = 'nightly'
+  }
 end)

--- a/.config/nvim/plugin/lspconfig.lua
+++ b/.config/nvim/plugin/lspconfig.lua
@@ -84,7 +84,7 @@ nvim_lsp.sourcekit.setup {
   capabilities = capabilities,
 }
 
-nvim_lsp.sumneko_lua.setup {
+nvim_lsp.lua_ls.setup {
   capabilities = capabilities,
   on_attach = function(client, bufnr)
     on_attach(client, bufnr)


### PR DESCRIPTION
Added the plugin [nvim-tree](https://github.com/nvim-tree/nvim-tree.lua) to the setup

- press 'tt' to toggle nvim tree.
- It automatically disables netrw, to enable it just change the value of the lines below to zero in 'nvimtree.rc.lua' or just delete the lines.
```lua
-- Disabling net and netrw for nvim-tree
vim.g.loaded_netrw = 1
vim.g.loaded_netrw_plugin = 1
```
