### PR TITLE
fix clipboard related lagging caused by irrelevant imports.

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -8,12 +8,12 @@ local is_mac = has "macunix"
 local is_win = has "win32"
 local is_wsl = has "wsl"
 
-if is_mac then
+if is_mac == 1 then
   require('craftzdog.macos')
 end
-if is_win then
+if is_win == 1 then
   require('craftzdog.windows')
 end
-if is_wsl then
+if is_wsl == 1 then
   require('craftzdog.wsl')
 end


### PR DESCRIPTION
when using this neovim config on macos, d/c (and other clipboard related) actions may cause a wsl clip.exe invocation which lags about 1 second.