### PR TITLE
feat(fish): Replacing exa with new eza

### DIFF
--- a/.config/fish/config-linux.fish
+++ b/.config/fish/config-linux.fish
@@ -1,4 +1,4 @@
-if type -q exa
-  alias ll "exa -l -g --icons"
+if type -q eza
+  alias ll "eza -l -g --icons"
   alias lla "ll -a"
 end


### PR DESCRIPTION
On my setup, exa was facing some issues. So I checked and found out the exa has shifted their setup to eza now. So I've changed my setup commands from exa to eza and everthing works fine as it is now