### PR TITLE
feat(tmux): Automated script to split tmux window, when you want to open your project folder.

### DIFF
--- a/.config/fish/config-linux.fish
+++ b/.config/fish/config-linux.fish
@@ -1,4 +1,8 @@
 if type -q eza
-  alias ll "eza -l -g --icons"
-  alias lla "ll -a"
+    alias ll "eza -l -g --icons"
+    alias lla "ll -a"
+end
+
+if type -q tmux
+    alias ide "~/.scripts/ide.sh"
 end

--- a/.config/fish/config-osx.fish
+++ b/.config/fish/config-osx.fish
@@ -1,6 +1,10 @@
 if type -q eza
-  alias ll "eza -l -g --icons"
-  alias lla "ll -a"
+    alias ll "eza -l -g --icons"
+    alias lla "ll -a"
+end
+
+if type -q tmux
+    alias ide "~/.scripts/ide.sh"
 end
 
 # Inkdrop

--- a/.scripts/ide.sh
+++ b/.scripts/ide.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+read -p "Enter the directory path: " path
+cd "$(path)"
+
+# Start a new tmux session with name "ide"
+tmux new-session -s ide -d
+
+# Create a new window named "editor"
+tmux rename-window -t ide:0 -n editor
+
+# Create a new window named "terminal"
+tmux new-window -t ide:1 -n terminal
+
+# Split the second window vertically into two panes
+tmux split-window -t ide:1 -v
+
+# Rename the first vertical pane to "directory"
+tmux select-pane -t ide:1.0 -T directory
+
+# Rename the second vertical pane to "shell"
+tmux select-pane -t ide:1.1 -T shell
+
+# Split the "shell" pane horizontally into two more panes
+tmux split-pane -t ide:1.1 -h
+
+# Attach to the "ide" session
+tmux select-window -t ide:0
+tmux attach-session -t ide


### PR DESCRIPTION
This is a script I've made for tmux to split open project folders in tmux in an already configured window split design.

Copy the `.scripts` folder to the home path (~). The alias is already written in fish config files. Copy the `fish` folder to use the `ide` alias

https://github.com/craftzdog/dotfiles-public/assets/51878195/96f9b557-1c7a-412c-8323-dd7fcf475212

