### PR TITLE
Tmux :  i set alacritty as default terminal in tmux for fixed status line colors problem

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -1,3 +1,5 @@
+#set -g default-terminal "alacritty" # if your terminal is alacritty uncommenting this code
+#set-option -ga terminal-overrides ",alacritty:Tc" # and this code
 #set -g default-terminal "tmux-256color"
 set -g default-terminal "xterm-256color"
 #set -ga terminal-overrides ",*256col*:Tc"


### PR DESCRIPTION
I used them codes for tmux status line in alacritty and you can see  a problem in this [issues](https://github.com/craftzdog/dotfiles-public/issues/152)