### PR TITLE
Update from deprecated calender_clock to new calender_clock unicode

### DIFF
--- a/.config/powershell/takuya.omp.json
+++ b/.config/powershell/takuya.omp.json
@@ -89,7 +89,7 @@
           "background": "#40c4ff",
           "foreground": "#ffffff",
           "properties": {
-            "prefix": " \uf5ef ",
+            "prefix": " \udb80\udcf0 ",
             "postfix": " "
         }
         }


### PR DESCRIPTION
Addresses #158 
![image](https://github.com/craftzdog/dotfiles-public/assets/17973367/42822e1e-305c-4537-84c7-05de147e4545)

Migrating to new calendar_clock unicode 