### PR TITLE
fix: Commitizen needs specify which command

### DIFF
--- a/.config/lazygit/config.yml
+++ b/.config/lazygit/config.yml
@@ -1,6 +1,6 @@
 customCommands:
   - key: "C"
-    command: "git cz"
+    command: "git cz c"
     description: "commit with commitizen"
     context: "files"
     loadingText: "opening commitizen commit tool"


### PR DESCRIPTION
Hi craftzdog,

When I follow your config for lazygit, whenever I click `C` it will show the CLI screen with only option `press enter to return to lazygit` and when I look at lazygit the example instruction is shown as

```yaml
customCommands:
  - key: "C"
    command: "git cz c"
    description: "commit with commitizen"
    context: "files"
    loadingText: "opening commitizen commit tool"
    subprocess: true
```

So it is likely we need to append `c` at the end of the command, to enhance normal `c` shortcut from lazygit to commitizen