### PR TITLE
refactor: reduce to single notified toast.

### DIFF
--- a/.config/nvim/lua/craftzdog/discipline.lua
+++ b/.config/nvim/lua/craftzdog/discipline.lua
@@ -2,26 +2,24 @@ local M = {}
 
 function M.cowboy()
 	---@type table?
-	local id
 	local ok = true
 	for _, key in ipairs({ "h", "j", "k", "l", "+", "-" }) do
 		local count = 0
-		local timer = assert(vim.loop.new_timer())
+		local timer = assert(vim.uv.new_timer())
 		local map = key
 		vim.keymap.set("n", key, function()
 			if vim.v.count > 0 then
 				count = 0
 			end
-			if count >= 10 then
-				ok, id = pcall(vim.notify, "Hold it Cowboy!", vim.log.levels.WARN, {
+			if count >= 10 and vim.bo.buftype ~= "nofile" then
+        			ok = pcall(vim.notify, "Hold it Cowboy!", vim.log.levels.WARN, {
 					icon = "🤠",
-					replace = id,
+					id = "cowboy",
 					keep = function()
 						return count >= 10
 					end,
 				})
 				if not ok then
-					id = nil
 					return map
 				end
 			else


### PR DESCRIPTION
### Description:
Since lazyvim introduces snacks.nvim, if we trigger "cowboy" event and keep holding navigation keys, it will keep generating notification toasts, with this change, only single notification shows when we hold keys.

### Changes:
- Updated the logic to ensure only a single notification is displayed while holding navigation keys.
- Introduced a conditional check for vim.bo.buftype ~= "nofile" to ensure notifications are contextually appropriate.
- Replaced the deprecated vim.loop.new_timer() with vim.uv.new_timer().
- Introduced a unique notification id ("cowboy") with a keep function to manage the persistence of the notification while holding keys.
- Improved error handling to gracefully fallback when vim.notify encounters an issue.

### How to Test:
- Open any buffer and press or hold the navigation keys (h, j, k, l, +, -).
- Observe that after 10 rapid presses, a single notification appears (“Hold it Cowboy!”).
- Ensure the notification does not repeat until keys are released and the event re-triggers.
- Verify the change works across different buffer types and does not interfere with navigation.