### PR TITLE
fix(nvim): copilot move extras from coding to ai

### DIFF
--- a/.config/nvim/lua/config/lazy.lua
+++ b/.config/nvim/lua/config/lazy.lua
@@ -33,7 +33,7 @@ require("lazy").setup({
 		-- { import = "lazyvim.plugins.extras.lang.markdown" },
 		{ import = "lazyvim.plugins.extras.lang.rust" },
 		{ import = "lazyvim.plugins.extras.lang.tailwind" },
-		{ import = "lazyvim.plugins.extras.coding.copilot" },
+		{ import = "lazyvim.plugins.extras.ai.copilot" },
 		-- { import = "lazyvim.plugins.extras.dap.core" },
 		-- { import = "lazyvim.plugins.extras.vscode" },
 		{ import = "lazyvim.plugins.extras.util.mini-hipatterns" },


### PR DESCRIPTION
This pull request includes a configuration in the `.config/nvim/lua/config/lazy.lua` file. The change updates the import path for the Copilot plugin from the **coding** category to the **AI** category.

* Updated the import path for the Copilot plugin from `lazyvim.plugins.extras.coding.copilot` to `lazyvim.plugins.extras.ai.copilot` in the `require("lazy").setup({...})` configuration.