### PR TITLE
feat(powershell): add optional cyberpunk theme with dashboard

### DIFF
--- a/.config/powershell/themes/cyberpunk/README.md
+++ b/.config/powershell/themes/cyberpunk/README.md
@@ -1,0 +1,63 @@
+# Cyberpunk Theme
+
+An optional cyberpunk-themed layer for the PowerShell setup.
+
+Adds a **startup dashboard** and replaces the default prompt with the **NETWATCH Oh My Posh theme** — without modifying any existing settings.
+
+## Preview
+
+![Cyberpunk Dashboard](../../../../img/preview-cyberpunk.png)
+
+## What it adds
+
+| Feature | Description |
+|---|---|
+| Startup dashboard | System Info · Shortcuts · Features · Live Docker status |
+| NETWATCH prompt | Oh My Posh theme with git branch, path, user, execution time |
+| `Write-Cyber` | ANSI helper to print any hex color in PowerShell |
+| Global palette `$CY` | Change the entire color scheme by editing 6 hex values |
+| `Show-Dashboard` | Re-run the dashboard at any time |
+| `help-ps` | Full help with tools, shortcuts and commands |
+
+## Activation
+
+Uncomment the last line in `user_profile.ps1`:
+
+```powershell
+. "$PSScriptRoot\themes\cyberpunk\cyberpunk.ps1"
+```
+
+## Customizing colors
+
+Edit `$global:CY` at the top of `cyberpunk.ps1`:
+
+```powershell
+$global:CY = @{
+    Yellow  = "#FCEE0A"   # Main accent
+    Green   = "#39FF14"   # Success
+    Cyan    = "#00F0FF"   # Info
+    Magenta = "#C678DD"   # Separators
+    Dark    = "#555555"   # Borders
+    Dim     = "#888888"   # Muted text
+}
+```
+
+## Reverting to original prompt
+
+To keep the dashboard but use Takuya's original prompt,
+comment out the Oh My Posh lines in `cyberpunk.ps1`:
+
+```powershell
+# $_ompTheme = Join-Path $PSScriptRoot "omp_cyberpunk.json"
+# if (Test-Path $_ompTheme) {
+#     oh-my-posh init pwsh --config $_ompTheme | Invoke-Expression
+# }
+```
+
+## What it does NOT change
+
+- `EditMode Emacs` — preserved
+- `Ctrl+F / Ctrl+R` fzf chords — preserved  
+- All existing aliases (`g`, `ll`, `vim`, `grep`, `tig`, `less`) — preserved
+- `$env:GIT_SSH` and PATH additions — preserved
+- `posh-git` module — preserved

--- a/.config/powershell/themes/cyberpunk/cyberpunk.ps1
+++ b/.config/powershell/themes/cyberpunk/cyberpunk.ps1
@@ -1,0 +1,216 @@
+# ================================================================= #
+#   Cyberpunk theme for craftzdog/dotfiles-public                   #
+#   Adds: NETWATCH Oh My Posh prompt + startup dashboard            #
+#                                                                   #
+#   Respects all existing settings from user_profile.ps1:          #
+#   - EditMode Emacs is preserved                                   #
+#   - Ctrl+f / Ctrl+r fzf chords are preserved                     #
+#   - All existing aliases are preserved                            #
+# ================================================================= #
+
+# ── ANSI color helper ─────────────────────────────────────────────
+function Write-Cyber {
+    param(
+        [string]$Text,
+        [string]$Color = "#FCEE0A",
+        [switch]$NoNewline
+    )
+    $esc   = [char]27
+    $r     = [Convert]::ToInt32($Color.Substring(1,2), 16)
+    $g     = [Convert]::ToInt32($Color.Substring(3,2), 16)
+    $b     = [Convert]::ToInt32($Color.Substring(5,2), 16)
+    $ansi  = "${esc}[38;2;${r};${g};${b}m"
+    $reset = "${esc}[0m"
+    if ($NoNewline) { Write-Host "$ansi$Text$reset" -NoNewline }
+    else            { Write-Host "$ansi$Text$reset" }
+}
+
+# ── Global color palette — edit hex values to restyle everything ──
+$global:CY = @{
+    Yellow  = "#FCEE0A"   # Main accent
+    Green   = "#39FF14"   # Success / git clean
+    Cyan    = "#00F0FF"   # Info / values
+    Magenta = "#C678DD"   # Separators / secondary
+    Dark    = "#555555"   # Borders
+    Dim     = "#888888"   # Muted text
+}
+
+# ── Oh My Posh — NETWATCH theme ───────────────────────────────────
+# Replaces the default takuya prompt with the NETWATCH cyberpunk prompt.
+# To revert to Takuya's original prompt, comment out these 2 lines:
+$_ompTheme = Join-Path $PSScriptRoot "omp_cyberpunk.json"
+if (Test-Path $_ompTheme) {
+    oh-my-posh init pwsh --config $_ompTheme | Invoke-Expression
+}
+
+# ── Startup dashboard ─────────────────────────────────────────────
+function Show-Dashboard {
+    $c = $global:CY
+
+    $cpuName = (Get-CimInstance Win32_Processor -ErrorAction SilentlyContinue)?.Name `
+        -replace 'AMD |Intel\(R\) | \d+-Core| Processor| @.*$', ''
+
+    $sysInfo = [ordered]@{
+        "Started" = (Get-Date -Format "yyyy-MM-dd HH:mm")
+        "Shell"   = "$($PSVersionTable.PSVersion.Major).$($PSVersionTable.PSVersion.Minor) $($PSVersionTable.PSEdition)"
+        "CPU"     = if ($cpuName) { $cpuName.Trim() } else { "N/A" }
+        "RAM"     = "{0:N2} GB" -f ((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1GB)
+        "User"    = "$env:USERNAME"
+        "OS"      = (Get-CimInstance Win32_OperatingSystem).Caption
+    }
+
+    # Edit shortcuts to match your own tools
+    $shortcuts = @(
+        @{ Label = "VS Code   (vsc)";  Value = "code ." }
+        @{ Label = "Neovim    (vim)";  Value = "nvim ." }
+        @{ Label = "Git log   (gl)";   Value = "git log --oneline" }
+        @{ Label = "Help      (help-ps)"; Value = "show all commands" }
+    )
+
+    $features = @(
+        @{ Key = "ls / dir";   Desc = "Terminal-Icons   ->  icons next to files" }
+        @{ Key = "Ctrl+F";     Desc = "Fzf Search       ->  interactive file finder" }
+        @{ Key = "Ctrl+R";     Desc = "Fzf History      ->  search command history" }
+        @{ Key = "Arrow  ->";  Desc = "Autocomplete     ->  accept grey suggestion" }
+        @{ Key = "which cmd";  Desc = "which            ->  find command path" }
+        @{ Key = "help-ps";    Desc = "Help             ->  list all commands" }
+    )
+
+    $sep  = "=" * 80
+    $sep2 = "-" * 80
+
+    Write-Cyber $sep $c.Magenta
+    Write-Host ""
+    Write-Cyber "$("System Info".PadRight(38))| Shortcuts" $c.Green
+    Write-Host ""
+
+    $maxLines = [Math]::Max($sysInfo.Count, $shortcuts.Count)
+    $sysKeys  = @($sysInfo.Keys)
+
+    for ($i = 0; $i -lt $maxLines; $i++) {
+        if ($i -lt $sysKeys.Count) {
+            $k = $sysKeys[$i]
+            Write-Cyber "$($k.PadRight(10))" $c.Yellow -NoNewline
+            Write-Cyber ": " $c.Magenta -NoNewline
+            Write-Cyber "$("$($sysInfo[$k])".PadRight(24))" $c.Cyan -NoNewline
+        } else {
+            Write-Host "".PadRight(38) -NoNewline
+        }
+        if ($i -lt $shortcuts.Count) {
+            Write-Cyber "| " $c.Magenta -NoNewline
+            Write-Cyber "$($shortcuts[$i].Label.PadRight(18))" $c.Yellow -NoNewline
+            Write-Cyber " $($shortcuts[$i].Value)" $c.Cyan
+        } else { Write-Host "" }
+    }
+
+    Write-Host ""
+    Write-Cyber $sep2 $c.Magenta
+    Write-Host ""
+    Write-Cyber "  Features" $c.Green
+    Write-Host ""
+    foreach ($f in $features) {
+        Write-Cyber "  $($f.Key.PadRight(14))" $c.Yellow -NoNewline
+        Write-Cyber "  $($f.Desc)" $c.Cyan
+    }
+
+    # Docker status
+    Write-Host ""
+    Write-Cyber $sep2 $c.Magenta
+    Write-Host ""
+    Write-Cyber "  Docker" $c.Green
+    Write-Host ""
+
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+        Write-Cyber "  Docker not installed or not in PATH." $c.Dim
+    } else {
+        try {
+            $containers = docker ps --format "{{.Names}}|{{.Image}}|{{.Status}}|{{.Ports}}" 2>$null
+            if ($containers) {
+                Write-Cyber "  $("NAME".PadRight(22)) $("IMAGE".PadRight(25)) $("STATUS".PadRight(20)) PORTS" $c.Cyan
+                Write-Cyber "  $("-" * 76)" $c.Dark
+                foreach ($line in $containers) {
+                    $p = $line -split "\|"
+                    Write-Cyber "  $($p[0].PadRight(22)) " $c.Yellow -NoNewline
+                    Write-Cyber "$($p[1].PadRight(25)) " $c.Cyan -NoNewline
+                    Write-Cyber "$($p[2].PadRight(20)) " $c.Green -NoNewline
+                    Write-Cyber "$(if ($p[3]) { $p[3] } else { '-' })" $c.Dim
+                }
+            } else {
+                Write-Cyber "  No active containers." $c.Dim
+            }
+        } catch {
+            Write-Cyber "  Could not connect to Docker daemon." $c.Dim
+        }
+    }
+
+    Write-Host ""
+    Write-Cyber $sep $c.Magenta
+    Write-Host ""
+}
+
+# ── Help ──────────────────────────────────────────────────────────
+function Show-Help {
+    $c   = $global:CY
+    $bar = "=" * 65
+
+    $tools = @(
+        @{ Name = "posh-git";       Use = "(automatic)";   Desc = "Git status in prompt" }
+        @{ Name = "Terminal-Icons"; Use = "ls / dir";       Desc = "Icons next to files and folders" }
+        @{ Name = "fzf (PSFzf)";   Use = "Ctrl+F";         Desc = "Interactive fuzzy file finder" }
+        @{ Name = "fzf history";   Use = "Ctrl+R";         Desc = "Search command history" }
+        @{ Name = "PSReadLine";    Use = "Arrow right";    Desc = "Accept autocomplete suggestion" }
+        @{ Name = "z (zoxide)";    Use = "z folder";       Desc = "Jump to frecent directories" }
+        @{ Name = "Oh My Posh";    Use = "(automatic)";    Desc = "NETWATCH cyberpunk prompt" }
+    )
+
+    $keys = @(
+        @{ Key = "Tab";             Desc = "Autocomplete commands and paths" }
+        @{ Key = "Ctrl+F";          Desc = "Open fzf file finder" }
+        @{ Key = "Ctrl+R";          Desc = "Search history with fzf" }
+        @{ Key = "Ctrl+D";          Desc = "Delete char (Emacs mode)" }
+        @{ Key = "Ctrl+A / Ctrl+E"; Desc = "Go to start / end of line" }
+        @{ Key = "Alt+D";           Desc = "Delete word forward" }
+        @{ Key = "Ctrl+W";          Desc = "Delete word backward" }
+    )
+
+    $cmds = @(
+        @{ Cmd = "Show-Dashboard";  Desc = "Show system dashboard" }
+        @{ Cmd = "which <cmd>";     Desc = "Find path of a command" }
+        @{ Cmd = "vim / nvim";      Desc = "Open Neovim" }
+        @{ Cmd = "g";               Desc = "git alias" }
+        @{ Cmd = "ll";              Desc = "ls alias" }
+        @{ Cmd = "help-ps";         Desc = "Show this help screen" }
+    )
+
+    Write-Host ""
+    Write-Cyber $bar $c.Magenta
+    Write-Cyber "  INSTALLED TOOLS" $c.Green
+    Write-Cyber $bar $c.Magenta
+    foreach ($t in $tools) {
+        Write-Cyber "  $($t.Name.PadRight(18))" $c.Yellow -NoNewline
+        Write-Cyber "$($t.Use.PadRight(18))" $c.Cyan -NoNewline
+        Write-Cyber "$($t.Desc)" $c.Dim
+    }
+    Write-Host ""
+    Write-Cyber $bar $c.Magenta
+    Write-Cyber "  KEYBOARD SHORTCUTS" $c.Green
+    Write-Cyber $bar $c.Magenta
+    foreach ($k in $keys) {
+        Write-Cyber "  $($k.Key.PadRight(22))" $c.Yellow -NoNewline
+        Write-Cyber "$($k.Desc)" $c.Cyan
+    }
+    Write-Host ""
+    Write-Cyber $bar $c.Magenta
+    Write-Cyber "  COMMANDS" $c.Green
+    Write-Cyber $bar $c.Magenta
+    foreach ($cmd in $cmds) {
+        Write-Cyber "  $($cmd.Cmd.PadRight(22))" $c.Yellow -NoNewline
+        Write-Cyber "$($cmd.Desc)" $c.Cyan
+    }
+    Write-Host ""
+}
+
+Set-Alias help-ps Show-Help
+
+# Show dashboard on startup
+Show-Dashboard

--- a/.config/powershell/themes/cyberpunk/omp_cyberpunk.json
+++ b/.config/powershell/themes/cyberpunk/omp_cyberpunk.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+  "blocks": [
+    {
+      "alignment": "left",
+      "segments": [
+        {
+          "background": "#FCEE0A",
+          "foreground": "#050505",
+          "style": "plain",
+          "template": "  NETWATCH ",
+          "type": "text"
+        },
+        {
+          "background": "#1A1A2E",
+          "foreground": "#FCEE0A",
+          "powerline_symbol": "",
+          "style": "powerline",
+          "template": " {{ .UserName }}{{ if .Root }} {{ end }} ",
+          "type": "session"
+        },
+        {
+          "background": "#C678DD",
+          "foreground": "#050505",
+          "powerline_symbol": "",
+          "style": "powerline",
+          "template": "  {{ .Path }} ",
+          "properties": {
+            "style": "folder",
+            "max_depth": 3,
+            "folder_separator_icon": "  "
+          },
+          "type": "path"
+        },
+        {
+          "background": "#39FF14",
+          "foreground": "#050505",
+          "powerline_symbol": "",
+          "style": "powerline",
+          "template": "  {{ .HEAD }}{{ if .Working.Changed }}  {{ .Working.String }}{{ end }}{{ if .Staging.Changed }}  {{ .Staging.String }}{{ end }} ",
+          "properties": {
+            "fetch_status": true,
+            "fetch_upstream_icon": true
+          },
+          "type": "git"
+        },
+        {
+          "background": "#1A1A2E",
+          "foreground": "#FCEE0A",
+          "powerline_symbol": "",
+          "style": "powerline",
+          "template": "  {{ .CurrentDate | date \"15:04\" }} ",
+          "type": "time"
+        }
+      ],
+      "type": "prompt"
+    },
+    {
+      "alignment": "right",
+      "segments": [
+        {
+          "background": "transparent",
+          "foreground": "#C678DD",
+          "style": "plain",
+          "template": "{{ if gt .Ms 500 }}⏱ {{ .FormattedMs }}{{ end }} ",
+          "properties": {
+            "always_enabled": false,
+            "threshold": 500
+          },
+          "type": "executiontime"
+        }
+      ],
+      "type": "rprompt"
+    },
+    {
+      "alignment": "left",
+      "newline": true,
+      "segments": [
+        {
+          "foreground": "#C678DD",
+          "style": "plain",
+          "template": "{{ if .Root }} {{ end }}",
+          "type": "session"
+        },
+        {
+          "foreground": "#FCEE0A",
+          "style": "plain",
+          "template": "❯ ",
+          "type": "text"
+        }
+      ],
+      "type": "prompt"
+    }
+  ],
+  "transient_prompt": {
+    "background": "transparent",
+    "foreground": "#FCEE0A",
+    "template": "❯ "
+  },
+  "secondary_prompt": {
+    "background": "transparent",
+    "foreground": "#C678DD",
+    "template": "❯❯ "
+  },
+  "version": 2
+}


### PR DESCRIPTION
## Add optional Cyberpunk theme for PowerShell

This PR adds an optional cyberpunk-themed layer to the existing PowerShell setup.

**Zero breaking changes** — activation requires uncommenting a single line in `user_profile.ps1`. Everything reverts by commenting it back.

### What it adds

- **Startup dashboard** — System Info, shortcuts, installed features and live Docker container status
- **NETWATCH Oh My Posh theme** — prompt with git branch, path, user and execution time
- **`Write-Cyber` helper** — write any hex color via ANSI in PowerShell
- **Global color palette** — restyle everything by editing 6 hex values
- **`help-ps` command** — full reference of tools, shortcuts and functions

### What it does NOT change

- `EditMode Emacs` — preserved
- `Ctrl+F / Ctrl+R` fzf chords — preserved
- All existing aliases (`g`, `ll`, `vim`, `grep`, `tig`, `less`) — preserved
- `$env:GIT_SSH` and PATH — preserved
- `posh-git` module — preserved

### Activation

Uncomment the last line in `user_profile.ps1`:
```powershell
. "$PSScriptRoot\themes\cyberpunk\cyberpunk.ps1"
```

Full standalone version: [HEO-80/powershell-cyberpunk](https://github.com/HEO-80/powershell-cyberpunk)